### PR TITLE
Add nbresult for Glovebox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/datascience-notebook:python-3.8.5
 LABEL maintainer="seb@lewagon.org"
 
 ENV LANG en_US.utf8
-RUN pip install pytest pylint lxml
+RUN pip install pytest pylint lxml nbresult
 
 ENV FULLSTACK_FOLDER /data-challenges
 WORKDIR $FULLSTACK_FOLDER


### PR DESCRIPTION
Now that our Notebooks are going to be tested with https://github.com/lewagon/nbresult, we need it on Glovebox!