### PR TITLE
remove make which is provided by the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.8.6-slim-buster
-RUN apt-get update && apt-get install -y --no-install-recommends make
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 


### PR DESCRIPTION
this follows https://github.com/lewagon/data-solutions/pull/785

`make` is already installed in the base image : [python:3.8.6-slim-buster](https://github.com/docker-library/python/blob/5590cdd4367f088277bb5494d0a0b0f65e9ab491/3.8/buster/slim/Dockerfile)
