### PR TITLE
Add tensorflow and pip no cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ FROM python:3.10.6-slim-buster
 RUN apt-get update && apt-get install -y --no-install-recommends make curl
 
 COPY requirements.txt /requirements.txt
-RUN pip install -r /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
 
 WORKDIR /workspace

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ dill==0.3.6
 executing==1.1.1
 flake8==4.0.1
 fonttools==4.38.0
+h5py==3.10.0
 idna==3.4
 iniconfig==1.1.1
 ipdb==0.13.9
@@ -57,6 +58,7 @@ setuptools-scm==6.4.2
 six==1.16.0
 soupsieve==2.3.2.post1
 stack-data==0.5.1
+tensorflow-cpu==2.10.0
 threadpoolctl==3.1.0
 toml==0.10.2
 tomli==2.0.1


### PR DESCRIPTION
Adding tensorflow for tests in DS Deep Learning week

- Using `tensorflow-cpu` to reduce image size (and no use for gpu anyway)
- Fix `h5py==3.10.0` because this has a wheel for arm64 (to allow building an image locally on Apple Silicon by content team to test)

Specify `--no-cache-dir` for `pip install` to reduce image size (no use for caching when building docker image anyway)